### PR TITLE
Removing newlines and punctuation from the input

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ future==0.16.0
 Cython==0.27.2
 cysignals==1.6.5
 pyfasttext==0.4.3
+regex==2019.3.12

--- a/whatthelang/predict_lang.py
+++ b/whatthelang/predict_lang.py
@@ -1,6 +1,6 @@
 from pyfasttext import FastText
 from os import path
-import re
+import regex as re
 
 MODEL_FILE = path.join(path.dirname(__file__), 'model', 'lid.176.ftz')
 
@@ -14,7 +14,7 @@ class WhatTheLang(object):
         return FastText(self.model_file)
 
     def _clean_up(self,txt):
-        txt = re.sub(r"\b\d+\b", "", txt)
+        txt = re.sub(r'(\b\d+\b|\p{P}|\n)', '', txt)
         return txt
 
     def _flatten(self,pred):


### PR DESCRIPTION
Had to add the `regex` package as `re` does not have a punctuation class.